### PR TITLE
feat: Add toggle for urgency display in notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,6 +432,19 @@
               <span class="slider"></span>
             </label>
           </div>
+
+          <div class="setting-item">
+            <div class="setting-info">
+              <div class="setting-label">
+                <span>⚠️</span> Show Urgency
+              </div>
+              <div class="setting-description">Display urgency level on notifications</div>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" id="urgencyToggle" checked>
+              <span class="slider"></span>
+            </label>
+          </div>
         </div>
       </div>
       

--- a/main.js
+++ b/main.js
@@ -22,7 +22,8 @@ let activeNotifications = new Set(); // Track active notification windows
 let settings = {
   enableSummary: false,
   enableVoiceReading: true,
-  huggingfaceToken: process.env.HUGGINGFACE_TOKEN
+  huggingfaceToken: process.env.HUGGINGFACE_TOKEN,
+  showUrgency: true
 };
 
 function createWindow() {
@@ -224,16 +225,18 @@ function createEnhancedNotificationHTML(emailData) {
 
   // Enhanced urgency badge with debugging
   let urgencyBadge = '';
-  console.log(`Urgency check: ${emailData.urgency} (type: ${typeof emailData.urgency})`);
-  
-  if (emailData.urgency === 'high') {
-    urgencyBadge = '<div class="urgency-badge high">🚨 Urgent</div>';
-    console.log("Adding HIGH urgency badge");
-  } else if (emailData.urgency === 'medium') {
-    urgencyBadge = '<div class="urgency-badge medium">⚠️ Important</div>';
-    console.log("Adding MEDIUM urgency badge");
-  } else {
-    console.log("No urgency badge (low urgency)");
+  if (settings.showUrgency) {
+    console.log(`Urgency check: ${emailData.urgency} (type: ${typeof emailData.urgency})`);
+
+    if (emailData.urgency === 'high') {
+      urgencyBadge = '<div class="urgency-badge high">🚨 Urgent</div>';
+      console.log("Adding HIGH urgency badge");
+    } else if (emailData.urgency === 'medium') {
+      urgencyBadge = '<div class="urgency-badge medium">⚠️ Important</div>';
+      console.log("Adding MEDIUM urgency badge");
+    } else {
+      console.log("No urgency badge (low urgency)");
+    }
   }
 
   const readTimeBadge = emailData.readTime ? 

--- a/renderer.js
+++ b/renderer.js
@@ -1,7 +1,8 @@
 let isMonitoring = false;
 let settings = {
   enableSummary: false,
-  enableVoiceReading: true
+  enableVoiceReading: true,
+  showUrgency: true // Add this line, defaulting to true
 };
 
 // UI Elements
@@ -35,6 +36,7 @@ function updateUI() {
 function updateSettingsUI() {
   document.getElementById('summaryToggle').checked = settings.enableSummary;
   document.getElementById('voiceToggle').checked = settings.enableVoiceReading;
+  document.getElementById('urgencyToggle').checked = settings.showUrgency; // Add this line
 }
 
 function setLoading(element, loading) {
@@ -66,9 +68,11 @@ async function saveSettings() {
   try {
     const summaryToggle = document.getElementById('summaryToggle');
     const voiceToggle = document.getElementById('voiceToggle');
+    const urgencyToggle = document.getElementById('urgencyToggle'); // Add this
     
     settings.enableSummary = summaryToggle.checked;
     settings.enableVoiceReading = voiceToggle.checked;
+    settings.showUrgency = urgencyToggle.checked; // Add this
     
     await window.gmail.updateSettings(settings);
     showSuccessFlash(document.querySelector('.settings-panel'));
@@ -225,6 +229,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   
   document.getElementById('summaryToggle').addEventListener('change', debouncedSave);
   document.getElementById('voiceToggle').addEventListener('change', debouncedSave);
+  document.getElementById('urgencyToggle').addEventListener('change', debouncedSave);
   
   // Keyboard shortcuts
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
This commit introduces a new feature allowing you to toggle the visibility of the urgency level (e.g., "Urgent", "Important") on desktop notifications.

Changes include:
- Added a `showUrgency` property to the settings in `main.js`, defaulting to true.
- Modified `createEnhancedNotificationHTML` in `main.js` to conditionally display the urgency badge based on the `showUrgency` setting.
- Added a new toggle switch in the settings panel in `index.html` for the "Show Urgency" option.
- Updated `renderer.js` to manage the state of the new toggle, load its value from settings, and save changes.