### PR TITLE
Fix: Remove calls to undefined checkSnoozedEmails function

### DIFF
--- a/main.js
+++ b/main.js
@@ -1059,10 +1059,6 @@ async function initializeGmail() {
   }
   
   gmail = google.gmail({ version: 'v1', auth: oAuth2Client });
-  
-  // Start checking for snoozed emails to restore
-  setInterval(checkSnoozedEmails, 60000); // Check every minute
-  checkSnoozedEmails(); // Initial check
 }
 
 


### PR DESCRIPTION
Removes calls to the non-existent `checkSnoozedEmails` function within `initializeGmail` in `main.js`. This resolves the `ReferenceError` occurring during initialization.

The snoozed email functionality was not implemented, and these calls were remnants causing the error.