### PR TITLE
feat: Add 'View All' button and Gmail-like email preview modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,8 @@
 
     .status-section {
       padding: 30px;
+      overflow-y: auto; /* Add scroll if content overflows vertically */
+      max-height: 60vh; /* Allow status section to take up to 60% of viewport height, then scroll */
     }
 
     .status-display {
@@ -199,6 +201,12 @@
     .btn-check {
       grid-column: 1 / -1;
       background: linear-gradient(135deg, #8b5cf6, #7c3aed);
+      color: white;
+    }
+
+    .btn-view-all {
+      grid-column: 1 / -1; /* Make it span full width like btn-check */
+      background: linear-gradient(135deg, #6c757d, #5a6268); /* A neutral/grey gradient */
       color: white;
     }
 
@@ -392,6 +400,9 @@
           <button class="control-btn btn-check" onclick="checkEmail()" id="checkBtn">
             <span>📬</span> Check Now
           </button>
+          <button class="control-btn btn-view-all" id="viewAllBtn">
+            <span>📄</span> View All
+          </button>
         </div>
         
         <div class="settings-panel">
@@ -515,5 +526,15 @@
   </div>
 
   <script src="renderer.js"></script>
+
+<div id="emailPreviewModal" style="display: none; position: fixed; z-index: 1000; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.6);">
+  <div style="background-color: #fefefe; margin: 5% auto; padding: 20px; border: 1px solid #888; width: 80%; height: 80%; border-radius: 12px; box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19); display: flex; flex-direction: column;">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+      <h2 style="font-size: 20px; font-weight: 600;">Email Preview</h2>
+      <span id="closeEmailPreviewModal" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
+    </div>
+    <iframe id="emailPreviewFrame" style="flex-grow: 1; width: 100%; height: 100%; border: 1px solid #ccc; border-radius: 8px;"></iframe>
+  </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a new "View All" button that allows you to preview the HTML content of your latest unread email in a modal dialog, mimicking how it might appear in Gmail.

Changes include:
- Added a "View All" button to the controls section in `index.html`.
- Implemented a modal dialog in `index.html` to display the email preview using an iframe.
- Added logic in `renderer.js` to handle the "View All" button click, fetch email data from the main process, and display it in the modal.
- Created a new IPC handler `get-latest-email-html` in `main.js` to retrieve the HTML content and base CSS for the latest unread email.
- Fixed a CSS issue where control buttons could be pushed out of the visible range by making the `.status-section` scrollable if its content is too tall.

The email preview uses the email's original HTML and applies a base set of CSS for rendering within the iframe.