### PR TITLE
fix: Remove base CSS from notification pop-up iframes

### DIFF
--- a/main.js
+++ b/main.js
@@ -825,7 +825,7 @@ function createEnhancedNotificationHTML(emailData) {
     emailBodyDisplayHTML = `
       <div class="body-html-container" style="height: 200px; max-height: 200px; overflow: hidden; background-color: #fff; border: 1px solid #eee; border-radius: 4px;">
         <iframe
-          srcdoc="${IFRAME_BASE_CSS}${notificationData.bodyHtml.replace(/"/g, '&quot;')}"
+          srcdoc="${notificationData.bodyHtml.replace(/"/g, '&quot;')}" /* IFRAME_BASE_CSS removed */
           style="width: 100%; height: 100%; border: none;"
           sandbox="${sandboxRules}"
         ></iframe>


### PR DESCRIPTION
Removes the injected IFRAME_BASE_CSS from the iframes used to display email HTML content within new email pop-up notifications.

This change addresses an issue where the base CSS was causing layout problems in the notification windows, such as pushing action buttons out of view. Email content in these pop-up notifications will now render using its own embedded styles or browser defaults for iframes.

The styling for the 'View All' email preview modal in the main application window remains unaffected.