### PR TITLE
feat: Display email body as plain text in pop-up notifications

### DIFF
--- a/main.js
+++ b/main.js
@@ -813,28 +813,15 @@ function createEnhancedNotificationHTML(emailData) {
   `;
 
   // Process body text
-  const plainBodyForDisplay = notificationData.body || 'No preview available';
-  let isPlainFallbackLong = false;
-  if (!notificationData.bodyHtml && plainBodyForDisplay.length > 2000) { // Check length of plain text
-      isPlainFallbackLong = true;
-  }
+  // const plainBodyForDisplay = notificationData.body || 'No preview available'; // Original line
+  // let isPlainFallbackLong = false; // Removed
+  // if (!notificationData.bodyHtml && plainBodyForDisplay.length > 2000) { // Check length of plain text // Removed
+  //     isPlainFallbackLong = true; // Removed
+  // } // Removed
 
-  let emailBodyDisplayHTML;
-  if (notificationData.bodyHtml) {
-    const sandboxRules = "allow-popups allow-scripts allow-same-origin";
-    emailBodyDisplayHTML = `
-      <div class="body-html-container" style="height: 200px; max-height: 200px; overflow: hidden; background-color: #fff; border: 1px solid #eee; border-radius: 4px;">
-        <iframe
-          srcdoc="${notificationData.bodyHtml.replace(/"/g, '&quot;')}" /* IFRAME_BASE_CSS removed */
-          style="width: 100%; height: 100%; border: none;"
-          sandbox="${sandboxRules}"
-        ></iframe>
-      </div>
-    `;
-  } else {
-    // Fallback to plain text
-    emailBodyDisplayHTML = `<div class="body-text" style="max-height: 200px; overflow-y: auto; padding: 8px; background-color: #fff; border: 1px solid #eee; border-radius: 4px;">${plainBodyForDisplay}</div>`;
-  }
+  // Always display plain text in notifications, escaping HTML characters
+  const plainBodyForDisplay = (notificationData.body || 'No body content available.').replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const emailBodyDisplayHTML = `<div class="body-text">${plainBodyForDisplay}</div>`;
 
   const finalHTML = `
     <!DOCTYPE html>
@@ -1289,7 +1276,6 @@ function createEnhancedNotificationHTML(emailData) {
             </div>
             <div class="subject">${notificationData.subject || 'No Subject'}</div>
             ${emailBodyDisplayHTML}
-            ${isPlainFallbackLong ? '<div class="long-content-indicator">📄 Long email - click to view full content in main app</div>' : ''}
           </div>
         </div>
         ${attachmentsHTML}


### PR DESCRIPTION
Modifies new email pop-up notifications to always display the email body content as plain text, instead of attempting to render HTML. This addresses layout issues within the notification window where complex HTML could push buttons or other elements out of view.

Changes:
- The `createEnhancedNotificationHTML` function in `main.js` now uses the `notificationData.body` (plain text) for the notification's email body display.
- The plain text is rendered within a `div` with the class `body-text`, which has appropriate CSS for max-height, scrolling, and text formatting (e.g., `white-space: pre-wrap`).
- Removed the iframe and HTML rendering logic previously used for email bodies in these pop-up notifications.

The "View All" feature in the main application window remains the designated place for viewing the full HTML version of emails. This change ensures that pop-up notifications are more robust and consistently laid out.