### PR TITLE
Fix: Ensure 'View Full Email' window gains focus

### DIFF
--- a/main.js
+++ b/main.js
@@ -241,6 +241,7 @@ function createAndShowEmailWindow(viewData) {
 
   emailViewWindow.once('ready-to-show', () => {
     emailViewWindow.show();
+    emailViewWindow.focus(); // Add this line
   });
 
   // Optional: Open DevTools for this new window for debugging


### PR DESCRIPTION
When opening an email in a new window via the 'View Full Email' quick action button in a notification, the new window was sometimes not gaining focus and appearing behind other application windows.

This commit modifies the `createAndShowEmailWindow` function in `main.js`. The `emailViewWindow.focus()` method is now called immediately after `emailViewWindow.show()` within the `ready-to-show` event listener. This ensures that the newly opened email window is brought to the foreground and gains focus.