### PR TITLE
Fix: Restore CSS styling to full email view window

### DIFF
--- a/main.js
+++ b/main.js
@@ -179,16 +179,19 @@ function createAndShowEmailWindow(viewData) {
     contentToLoad = '<p>No content available for this email.</p>';
   }
 
+  // Combine base CSS with the email content
+  const combinedContent = IFRAME_BASE_CSS + contentToLoad;
+
   // Replace special characters in srcdoc to avoid breaking the HTML attribute.
   // Primarily " and &, but also ' can be problematic.
-  const iframeSrcDoc = contentToLoad
+  const iframeSrcDoc = combinedContent
     .replace(/"/g, '&quot;')
     .replace(/&/g, '&amp;') // Must be done after other entities that use & if they exist
     .replace(/'/g, '&#39;');
 
 
   // Construct the HTML for the new window. This HTML will contain an iframe.
-  // No IFRAME_BASE_CSS is injected here.
+  // IFRAME_BASE_CSS is now injected via combinedContent into iframeSrcDoc.
   const newWindowHtml = `
     <!DOCTYPE html>
     <html>


### PR DESCRIPTION
The dedicated window for viewing a full email (opened via the 'View Full Email' quick action) was not applying the intended base CSS styles, making the email content appear unstyled.

This commit modifies the `createAndShowEmailWindow` function in `main.js`. The `IFRAME_BASE_CSS` constant, which contains the default styles, is now correctly prepended to the email's HTML content before being set as the `srcdoc` for the iframe. This ensures that the base styles are applied to the email content displayed in the iframe.