### PR TITLE
Fix: Correct HTML escaping for srcdoc in email view window

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,10 +184,7 @@ function createAndShowEmailWindow(viewData) {
 
   // Replace special characters in srcdoc to avoid breaking the HTML attribute.
   // Primarily " and &, but also ' can be problematic.
-  const iframeSrcDoc = combinedContent
-    .replace(/"/g, '&quot;')
-    .replace(/&/g, '&amp;') // Must be done after other entities that use & if they exist
-    .replace(/'/g, '&#39;');
+  const iframeSrcDoc = combinedContent.replace(/"/g, '&quot;');
 
 
   // Construct the HTML for the new window. This HTML will contain an iframe.


### PR DESCRIPTION
Addresses an issue where CSS styles were not appearing in the "View Full Email" window. The problem was caused by over-aggressive HTML escaping of the content passed to the iframe's srcdoc attribute, specifically the incorrect handling of ampersands, leading to double-escaping of existing HTML entities (e.g., &quot; becoming &amp;quot;).

This commit modifies the `createAndShowEmailWindow` function in `main.js`. The creation of `iframeSrcDoc` now only escapes double quotes (`"`) to `&quot;`. This prevents the double-escaping of other entities and allows the browser to correctly parse and render the HTML content and the prepended IFRAME_BASE_CSS within the iframe.