### PR TITLE
Style: Finalize IFRAME_BASE_CSS for cleaner email rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -831,7 +831,7 @@ const IFRAME_BASE_CSS = `
           /* word-wrap and overflow-wrap on table itself might be less effective than on cells */
         }
         td, th {
-          border: 1px solid #ddd;
+          border: none; /* MODIFIED */
           padding: 8px;
           text-align: left;
           word-wrap: break-word;   /* Still important for content within cells */


### PR DESCRIPTION
This commit includes two main improvements to IFRAME_BASE_CSS to ensure emails rendered within iframes are cleaner and more faithful to their original styling:

1.  Ensure Universal Outline Reset: Confirmed and ensured that the rule `* { outline: none !important; outline-style: none !important; -moz-outline-style: none !important; }` is present in `IFRAME_BASE_CSS`. This prevents default browser outlines from appearing on focused elements within the iframe.

2.  Remove Default Table Cell Borders: Changed the `td, th` style rule within `IFRAME_BASE_CSS` from `border: 1px solid #ddd;` to `border: none;`. This removes the light gray borders that were previously applied to all table cells by default, allowing emails to define their own table borders or have none, as intended by their design. This addresses your feedback about unwanted "gray lines".