### PR TITLE
Fix: Ensure tone analysis respects the 'showUrgency' setting

### DIFF
--- a/main.js
+++ b/main.js
@@ -464,7 +464,12 @@ async function getEmailDetails(messageId) {
 
     console.log(`Processing email: "${subject}" from ${fromHeader}`);
 
-    const tone = await detectEmotionalTone(contentForAnalysis);
+    let tone;
+    if (settings.showUrgency) {
+      tone = await detectEmotionalTone(contentForAnalysis);
+    } else {
+      tone = { label: 'NEUTRAL', score: 0.0, urgency: 'low', analysis_source: 'disabled_setting' };
+    }
     const readTime = estimateReadTime(textContent);
 
     return {
@@ -477,7 +482,7 @@ async function getEmailDetails(messageId) {
       id: messageId,
       tone,
       readTime,
-      urgency: tone.urgency
+      urgency: tone.urgency // This will correctly use the tone object from the conditional logic
     };
   } catch (error) {
     console.error(`Error getting email details for ${messageId}:`, error);


### PR DESCRIPTION
The tone analysis process was being triggered even when the 'showUrgency' setting was disabled. This commit modifies the `getEmailDetails` function in `main.js` to conditionally execute `detectEmotionalTone` based on the `settings.showUrgency` value.

- If `settings.showUrgency` is true, tone analysis proceeds as normal.
- If `settings.showUrgency` is false, the call to `detectEmotionalTone` is skipped, and a default tone object (`{ label: 'NEUTRAL', score: 0.0, urgency: 'low', analysis_source: 'disabled_setting' }`) is used.

This ensures that resources are not unnecessarily consumed by the tone analysis Python script when the feature is turned off by you. The application handles the absence of detailed tone analysis gracefully by defaulting to 'low' urgency.