### PR TITLE
Refactor: Replace email view options with appearance themes and enfor…

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,38 +641,41 @@
             </label>
           </div>
 
-          <!-- Sub-heading for Email View Preference -->
-          <div style="padding: 10px 0 5px 0; color: var(--main-text); font-size: 16px; font-weight: bold; border-bottom: 1px solid var(--border-color); margin-bottom: 5px;">
-            View Emails Using:
-          </div>
+        </div>
 
-          <!-- App Window Toggle -->
-          <div class="setting-item">
-            <div class="setting-info">
-              <div class="setting-label" style="font-size: 13px;">
-                <span>🖥️</span> App Window
-              </div>
-              <div class="setting-description" style="font-size: 11px;">View emails in a new window within this application.</div>
-            </div>
-            <label class="toggle">
-              <input type="checkbox" id="viewInAppWindowToggle">
-              <span class="slider"></span>
+        <!-- Sub-heading for Appearance -->
+        <div style="padding: 10px 0 5px 0; color: var(--main-text); font-size: 16px; font-weight: bold; border-bottom: 1px solid var(--border-color); margin-bottom: 5px;">
+          Appearance:
+        </div>
+
+        <!-- Dark Theme Radio Button -->
+        <div class="setting-item">
+          <div class="setting-info">
+            <label for="themeDark" class="setting-label" style="font-size: 13px;">
+              <span>🌙</span> Dark
             </label>
           </div>
+          <input type="radio" id="themeDark" name="theme" value="dark" checked>
+        </div>
 
-          <!-- Gmail Toggle -->
-          <div class="setting-item">
-            <div class="setting-info">
-              <div class="setting-label" style="font-size: 13px;">
-                <span>🌐</span> Gmail
-              </div>
-              <div class="setting-description" style="font-size: 11px;">View emails directly in the Gmail web application.</div>
-            </div>
-            <label class="toggle">
-              <input type="checkbox" id="viewInGmailToggle">
-              <span class="slider"></span>
+        <!-- Light Theme Radio Button -->
+        <div class="setting-item">
+          <div class="setting-info">
+            <label for="themeLight" class="setting-label" style="font-size: 13px;">
+              <span>☀️</span> Light
             </label>
           </div>
+          <input type="radio" id="themeLight" name="theme" value="light">
+        </div>
+
+        <!-- Midnight Theme Radio Button -->
+        <div class="setting-item">
+          <div class="setting-info">
+            <label for="themeMidnight" class="setting-label" style="font-size: 13px;">
+              <span>🌃</span> Midnight
+            </label>
+          </div>
+          <input type="radio" id="themeMidnight" name="theme" value="midnight">
         </div>
       </div>
 


### PR DESCRIPTION
…ce Gmail for viewing

This commit introduces a significant UI and behavior change:

1.  Removed the previous settings for choosing how to view emails (in-app window vs. Gmail). The application will now always open emails directly in the Gmail web application.
2.  Introduced new appearance theme settings: "Dark" (default), "Light", and "Midnight". You can now select your preferred theme.
3.  Implemented the necessary HTML, CSS (via JavaScript-managed CSS variables), and JavaScript logic to support these themes and allow dynamic switching.
4.  The "View All" email preview modal now also respects the selected theme, ensuring a consistent user experience.

Changes made:
- Modified `index.html`:
    - Removed the "View Emails Using" toggles.
    - Added radio buttons for "Dark", "Light", and "Midnight" themes.
- Modified `renderer.js`:
    - Removed logic for `viewEmailPreference`.
    - Added `appearanceTheme` to settings.
    - Implemented `applyTheme()` to change CSS variables based on the selected theme.
    - Updated settings load/save and event listeners for theme management.
- Modified `main.js`:
    - Removed `viewEmailPreference` from settings.
    - Updated `createAndShowEmailWindow()` to always open emails in Gmail using `shell.openExternal()`.
    - Removed code for creating in-app email view windows.
    - Implemented dynamic generation of `IFRAME_BASE_CSS` based on the selected theme so that the email preview modal in "View All" matches the application theme.
    - Added `appearanceTheme` to initial settings.