### PR TITLE
Feat: Implement styled toggle buttons for theme selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,62 @@
     .btn-check:hover, .btn-view-all:hover {
       background-color: var(--button-bg); /* Use standard button hover */
     }
+
+    .theme-button-group {
+      display: flex;
+      gap: 10px; /* Space between buttons */
+      margin-top: 10px; /* Space above the button group */
+      margin-bottom: 15px; /* Space below the button group */
+      padding: 10px; /* Padding around the group */
+      background-color: var(--tertiary-bg); /* Background for the group itself */
+      border-radius: 6px; /* Rounded corners for the group */
+      border: 1px solid var(--border-color);
+    }
+
+    .theme-btn {
+      flex-grow: 1; /* Make buttons share space equally */
+      background-color: var(--button-bg);
+      color: var(--main-text);
+      border: 1px solid var(--border-color);
+      border-radius: 5px;
+      padding: 8px 12px; /* Slightly adjusted padding */
+      font-size: 13px; /* Slightly smaller font */
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s ease, transform 0.1s ease, border-color 0.2s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px; /* Space between icon and text */
+      text-align: center;
+    }
+
+    .theme-btn:hover {
+      background-color: var(--button-hover-bg);
+      transform: translateY(-1px);
+      border-color: var(--lighter-purple); /* Highlight border on hover */
+    }
+
+    .theme-btn.active {
+      background-color: var(--accent-purple);
+      color: var(--main-text); /* Ensure text is readable */
+      border-color: var(--lighter-purple); /* Stronger border for active state */
+      box-shadow: 0 0 8px var(--accent-purple); /* Add a glow effect */
+      transform: translateY(-1px); /* Keep it slightly elevated */
+    }
+
+    .theme-btn:disabled { /* If we ever need to disable them */
+      opacity: 0.5;
+      cursor: not-allowed;
+      background-color: var(--tertiary-bg);
+      transform: none;
+    }
+
+    /* Ensure icons within buttons are vertically aligned if needed */
+    .theme-btn span {
+      display: inline-flex;
+      align-items: center;
+    }
     
     /* Settings Panel already covered by .glass-card like styling */
     .settings-title {
@@ -648,34 +704,10 @@
           Appearance:
         </div>
 
-        <!-- Dark Theme Radio Button -->
-        <div class="setting-item">
-          <div class="setting-info">
-            <label for="themeDark" class="setting-label" style="font-size: 13px;">
-              <span>🌙</span> Dark
-            </label>
-          </div>
-          <input type="radio" id="themeDark" name="theme" value="dark" checked>
-        </div>
-
-        <!-- Light Theme Radio Button -->
-        <div class="setting-item">
-          <div class="setting-info">
-            <label for="themeLight" class="setting-label" style="font-size: 13px;">
-              <span>☀️</span> Light
-            </label>
-          </div>
-          <input type="radio" id="themeLight" name="theme" value="light">
-        </div>
-
-        <!-- Midnight Theme Radio Button -->
-        <div class="setting-item">
-          <div class="setting-info">
-            <label for="themeMidnight" class="setting-label" style="font-size: 13px;">
-              <span>🌃</span> Midnight
-            </label>
-          </div>
-          <input type="radio" id="themeMidnight" name="theme" value="midnight">
+        <div class="theme-button-group" style="margin-top: 10px; margin-bottom: 10px;"> <!-- Added margin-bottom for spacing -->
+          <button id="btnThemeDark" class="theme-btn"><span>🌙</span> Dark</button>
+          <button id="btnThemeLight" class="theme-btn"><span>☀️</span> Light</button>
+          <button id="btnThemeMidnight" class="theme-btn"><span>🌃</span> Midnight</button>
         </div>
       </div>
 

--- a/renderer.js
+++ b/renderer.js
@@ -71,6 +71,10 @@ const addNotifiableAuthorBtn = document.getElementById('addNotifiableAuthorBtn')
 const notifiableAuthorsListUL = document.getElementById('notifiableAuthorsList'); // Renamed for clarity
 const noNotifiableAuthorsMsg = document.getElementById('noNotifiableAuthorsMsg');
 
+const btnThemeDark = document.getElementById('btnThemeDark');
+const btnThemeLight = document.getElementById('btnThemeLight');
+const btnThemeMidnight = document.getElementById('btnThemeMidnight');
+
 // At the top of renderer.js, add new UI element references
 const viewAllBtn = document.getElementById('viewAllBtn');
 const emailPreviewModal = document.getElementById('emailPreviewModal');
@@ -217,18 +221,7 @@ function updateSettingsUI() {
   document.getElementById('speakSenderNameToggle').disabled = !voiceToggleState;
   document.getElementById('speakSubjectToggle').disabled = !voiceToggleState;
 
-  // Update Theme Radio Buttons
-  const themeDark = document.getElementById('themeDark');
-  const themeLight = document.getElementById('themeLight');
-  const themeMidnight = document.getElementById('themeMidnight');
-
-  if (settings.appearanceTheme === 'light') {
-    themeLight.checked = true;
-  } else if (settings.appearanceTheme === 'midnight') {
-    themeMidnight.checked = true;
-  } else { // Default to dark
-    themeDark.checked = true;
-  }
+  updateActiveThemeButton(settings.appearanceTheme);
 }
 
 function setLoading(element, loading) {
@@ -273,14 +266,7 @@ async function saveSettings() {
     settings.speakSenderName = speakSenderNameToggle.checked; 
     settings.speakSubject = speakSubjectToggle.checked;
 
-    // Save Appearance Theme
-    if (document.getElementById('themeLight').checked) {
-      settings.appearanceTheme = 'light';
-    } else if (document.getElementById('themeMidnight').checked) {
-      settings.appearanceTheme = 'midnight';
-    } else {
-      settings.appearanceTheme = 'dark';
-    }
+    // settings.appearanceTheme is now set directly by button click handlers
     
     await window.gmail.updateSettings(settings);
     showSuccessFlash(document.querySelector('.settings-panel'));
@@ -446,26 +432,33 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('speakSenderNameToggle').addEventListener('change', debouncedSave); 
   document.getElementById('speakSubjectToggle').addEventListener('change', debouncedSave);
 
-  // Theme Radio Button Listeners
-  const themeDarkRadio = document.getElementById('themeDark');
-  const themeLightRadio = document.getElementById('themeLight');
-  const themeMidnightRadio = document.getElementById('themeMidnight');
-
-  function handleThemeChange(themeValue) {
-    // No need to update settings.appearanceTheme here, saveSettings will do it.
-    debouncedSave();
-    applyTheme(themeValue); // Call placeholder function
+  // New Theme Button Listeners
+  if (btnThemeDark) { // Add checks to ensure elements exist
+    btnThemeDark.addEventListener('click', () => {
+      settings.appearanceTheme = 'dark';
+      applyTheme('dark');
+      saveSettings(); // Direct call, or debouncedSave if preferred
+      updateActiveThemeButton('dark');
+    });
   }
 
-  themeDarkRadio.addEventListener('change', () => {
-    if (themeDarkRadio.checked) handleThemeChange('dark');
-  });
-  themeLightRadio.addEventListener('change', () => {
-    if (themeLightRadio.checked) handleThemeChange('light');
-  });
-  themeMidnightRadio.addEventListener('change', () => {
-    if (themeMidnightRadio.checked) handleThemeChange('midnight');
-  });
+  if (btnThemeLight) {
+    btnThemeLight.addEventListener('click', () => {
+      settings.appearanceTheme = 'light';
+      applyTheme('light');
+      saveSettings();
+      updateActiveThemeButton('light');
+    });
+  }
+
+  if (btnThemeMidnight) {
+    btnThemeMidnight.addEventListener('click', () => {
+      settings.appearanceTheme = 'midnight';
+      applyTheme('midnight');
+      saveSettings();
+      updateActiveThemeButton('midnight');
+    });
+  }
 
   document.getElementById('voiceToggle').addEventListener('change', () => {
     // Update the settings object directly for immediate reflection in updateSettingsUI
@@ -534,6 +527,20 @@ function applyTheme(themeName) {
   // The actual email content styling is handled in main.js by `renderEmailHTML`.
   // We need to ensure main.js is aware of the theme to style the email iframe content appropriately.
   // For now, we'll focus on the main app theme. The iframe part will be addressed in step 4 if needed.
+}
+
+function updateActiveThemeButton(themeName) {
+  if (btnThemeDark) btnThemeDark.classList.remove('active');
+  if (btnThemeLight) btnThemeLight.classList.remove('active');
+  if (btnThemeMidnight) btnThemeMidnight.classList.remove('active');
+
+  if (themeName === 'dark' && btnThemeDark) {
+    btnThemeDark.classList.add('active');
+  } else if (themeName === 'light' && btnThemeLight) {
+    btnThemeLight.classList.add('active');
+  } else if (themeName === 'midnight' && btnThemeMidnight) {
+    btnThemeMidnight.classList.add('active');
+  }
 }
 
 // --- NOTIFIABLE AUTHORS UI LOGIC ---


### PR DESCRIPTION
I replaced the radio button-based theme selection with a styled button group for a more consistent and user-friendly UI.

Previously, theme selection (Dark, Light, Midnight) used standard radio buttons with minimal styling. This change introduces a set of three buttons that visually indicate the active theme and behave like a toggle group.

Changes include:
- In `index.html`:
    - I removed the old radio button elements for theme selection.
    - I added a `div.theme-button-group` containing three new `<button>` elements (`btnThemeDark`, `btnThemeLight`, `btnThemeMidnight`).
    - I added CSS rules to style the button group, individual theme buttons (`.theme-btn`), and their active state (`.theme-btn.active`).
- In `renderer.js`:
    - I updated JavaScript to get references to the new button elements.
    - I replaced event listeners for radio buttons with new click listeners for the theme buttons.
    - I implemented logic to update `settings.appearanceTheme`, apply the theme via `applyTheme()`, save settings, and manage the `.active` class on the buttons.
    - I modified `updateSettingsUI()` to correctly set the active state on the new buttons when settings are loaded.
    - I adjusted `saveSettings()` to reflect that `settings.appearanceTheme` is now updated by the button click handlers directly.

This enhancement provides a more aesthetically pleasing and intuitive way for you to switch between application themes.