### PR TITLE
feat: Mirror main process console logs to renderer DevTools

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -6,7 +6,8 @@ const validReceiveChannels = [
   'display-email-in-modal',
   'display-email-in-modal-error',
   'email-count-update',
-  'new-email' // Assuming this is used from main.js to renderer.js for new email notifications shown in-app
+  'new-email', // Assuming this is used from main.js to renderer.js for new email notifications shown in-app
+  'console-log-from-main' // Added for receiving main process logs
   // Add any other channels that main.js sends to renderer.js for the main window
 ];
 
@@ -97,6 +98,19 @@ contextBridge.exposeInMainWorld('gmail', {
 });
 
 console.log('[Preload] Gmail API exposed to renderer.');
+
+// Expose a specific listener for main process logs
+contextBridge.exposeInMainWorld('mainProcessLogs', {
+  onLog: (callback) => {
+    const listener = (event, logEntry) => callback(logEntry);
+    ipcRenderer.on('console-log-from-main', listener);
+    return () => {
+      ipcRenderer.removeListener('console-log-from-main', listener);
+    };
+  }
+});
+
+console.log('[Preload] mainProcessLogs API exposed to renderer.');
 
 // Define channels for electronAPI (for notification windows)
 const validNotificationInvokeChannels = [

--- a/renderer.js
+++ b/renderer.js
@@ -400,6 +400,34 @@ window.addEventListener('beforeunload', () => {
     cleanupEmailCountUpdate();
   }
   // If other .on listeners are added, their cleanup functions should be called here too.
+  if (typeof cleanupMainProcessLogs === 'function') {
+    cleanupMainProcessLogs();
+  }
+});
+
+// --- MAIN PROCESS LOG LISTENER ---
+const cleanupMainProcessLogs = window.mainProcessLogs.onLog((logEntry) => {
+  const { type, messages } = logEntry;
+  const prefix = `[MAIN]`;
+  switch (type) {
+    case 'log':
+      console.log(prefix, ...messages);
+      break;
+    case 'warn':
+      console.warn(prefix, ...messages);
+      break;
+    case 'error':
+      console.error(prefix, ...messages);
+      break;
+    case 'info':
+      console.info(prefix, ...messages);
+      break;
+    case 'debug':
+      console.debug(prefix, ...messages);
+      break;
+    default:
+      console.log(`[MAIN - unknown type: ${type}]`, ...messages);
+  }
 });
 
 // --- THEME APPLICATION LOGIC ---


### PR DESCRIPTION
Overrides console.log, console.warn, console.error, console.info, and console.debug in the main process.

These overridden functions now send their arguments to the renderer process via IPC. The renderer process listens for these IPC messages and outputs the logs to its own DevTools console, prefixed with '[MAIN]' and using the corresponding log level.

This allows developers to see logs from both processes in a single console during development.